### PR TITLE
feat: add default .htmlhintrc with project override support

### DIFF
--- a/images/builder/.htmlhintrc
+++ b/images/builder/.htmlhintrc
@@ -1,0 +1,20 @@
+{
+  "tagname-lowercase": true,
+  "attr-lowercase": true,
+  "attr-value-double-quotes": false,
+  "doctype-first": false,
+  "tag-pair": false,
+  "spec-char-escape": true,
+  "id-unique": true,
+  "src-not-empty": true,
+  "attr-no-duplication": true,
+  "title-require": false,
+  "alt-require": true,
+  "doctype-html5": true,
+  "style-disabled": false,
+  "inline-script-disabled": true,
+  "inline-style-disabled": false,
+  "space-tab-mixed-disabled": "space",
+  "id-class-ad-disabled": true,
+  "attr-unsafe-chars": true
+}

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -23,7 +23,7 @@ COPY package.json package-lock.json /builder/
 RUN cd /builder && npm ci && npm link
 
 # Install pipeline defaults and scripts
-COPY defaults.json /builder/defaults.json
+COPY defaults.json .htmlhintrc /builder/
 COPY bin/copy-assets /usr/local/bin/copy-assets
 COPY bin/run-phase /usr/local/bin/run-phase
 RUN chmod +x /usr/local/bin/copy-assets /usr/local/bin/run-phase

--- a/images/builder/defaults.json
+++ b/images/builder/defaults.json
@@ -9,7 +9,7 @@
   },
   "lint": {
     "steps": [
-      "htmlhint ${HUGO_SOURCE:-.}/${OUTPUT:-public}/**/*.html || true"
+      "htmlhint --config $([ -f .htmlhintrc ] && echo .htmlhintrc || echo /builder/.htmlhintrc) ${HUGO_SOURCE:-.}/${OUTPUT:-public}/**/*.html || true"
     ]
   },
   "test": {


### PR DESCRIPTION
Adds a default .htmlhintrc to the builder image.

**Behavior:**
- If project has `.htmlhintrc` in root → uses project config
- If no `.htmlhintrc` → uses `/builder/.htmlhintrc` default

Projects can override by adding their own `.htmlhintrc`.