### PR TITLE
fix: remove double eval that breaks && and || in commands

### DIFF
--- a/images/builder/bin/run-phase
+++ b/images/builder/bin/run-phase
@@ -41,9 +41,7 @@ fi
 
 echo "=== Running phase: $PHASE ==="
 echo "$STEPS" | while IFS= read -r cmd; do
-  # Expand environment variables in command
-  expanded=$(eval echo "$cmd")
-  echo "+ $expanded"
-  eval "$expanded"
+  echo "+ $cmd"
+  eval "$cmd"
 done
 echo "=== Phase $PHASE complete ==="


### PR DESCRIPTION
The `eval echo` was executing commands during variable expansion, breaking conditional operators like `&&` and `||`.